### PR TITLE
Feat-04 : 클라이언트 메인 QA 관련사항 진행

### DIFF
--- a/app/(client)/(backButtonHeader)/birth-day/[isbn]/Before.tsx
+++ b/app/(client)/(backButtonHeader)/birth-day/[isbn]/Before.tsx
@@ -1,0 +1,68 @@
+import LoadingSpinner from "@/components/common/LoadingSpinner";
+import { CSVBook } from "@/types/api";
+import getConfig from "next/config";
+import { Suspense } from "react";
+import BookHeaderHelper from "../../book/[isbn]/BookHeaderHelper";
+import BookDetailCsv from "@/components/bookDetail/BookDetailCsv";
+
+export const dynamic = "force-static";
+export const revalidate = 86400; // 캐시를 너무 오래 저장하면 더 중요한 캐시 정보(getBirthdayBook 함수처럼 무거운거)가 제거될 수 있으므로 생일도서가 변경되는 24시간만 유효하도록 설정함
+
+const BirthDayBookDetailpage = async ({
+  params,
+}: {
+  params: Promise<{ isbn?: number }>;
+}) => {
+  const { isbn } = await params;
+  const suspenseResource = fetchCsvBookDataSuspense(isbn);
+  return (
+    <>
+      <BookHeaderHelper bookData={undefined} isbn={isbn!} />
+      <main className="flex size-full flex-1 items-center gap-8">
+        <Suspense fallback={<LoadingSpinner className="h-[50vw] w-full" />}>
+          <BookDetailCsv<CsvSuspenseResource>
+            suspenseResource={suspenseResource}
+          />
+        </Suspense>
+      </main>
+    </>
+  );
+};
+
+export default BirthDayBookDetailpage;
+
+export type CsvSuspenseResource = {
+  read: () => CSVBook[];
+};
+const fetchCsvBookDataSuspense = (isbn?: number): CsvSuspenseResource => {
+  let data: CSVBook[] | undefined;
+  let promise: Promise<CSVBook[] | undefined>;
+  return {
+    read: () => {
+      if (data) return data;
+      if (!promise)
+        promise = fetchCsvData(isbn).then((result) => (data = result));
+      throw promise;
+    },
+  };
+};
+
+const fetchCsvData = async (isbn?: number) => {
+  if (!isbn) throw new Error("ISBN is required");
+  try {
+    const { publicRuntimeConfig } = getConfig();
+    const baseUrl = publicRuntimeConfig.VERCEL_PROJECT_PRODUCTION_URL;
+    const response = await fetch(`${baseUrl}/api/book?isbn=` + isbn, {
+      cache: "force-cache",
+      next: { revalidate: 86400, tags: [isbn.toString()] },
+    });
+    if (!response.ok) throw new Error("Failed to fetch data");
+    const data = await response.json();
+    const keys = Object.keys(data.data);
+    const parseData: CSVBook[] = keys.map((key) => data.data[key]);
+    return parseData;
+  } catch (error) {
+    console.error("Error fetching CSV data:", error);
+    throw error;
+  }
+};

--- a/app/(client)/(backButtonHeader)/birth-day/[isbn]/page.tsx
+++ b/app/(client)/(backButtonHeader)/birth-day/[isbn]/page.tsx
@@ -1,12 +1,8 @@
-import BookDetail from "@/components/bookDetail/BookDetail";
 import LoadingSpinner from "@/components/common/LoadingSpinner";
-import { CSVBook } from "@/types/api";
-import getConfig from "next/config";
+import { getBookDetail } from "@/function/get/client";
 import { Suspense } from "react";
 import BookHeaderHelper from "../../book/[isbn]/BookHeaderHelper";
-
-export const dynamic = "force-static";
-export const revalidate = 86400; // 캐시를 너무 오래 저장하면 더 중요한 캐시 정보(getBirthdayBook 함수처럼 무거운거)가 제거될 수 있으므로 생일도서가 변경되는 24시간만 유효하도록 설정함
+import BookDetail from "@/components/bookDetail/BookDetail";
 
 const BirthDayBookDetailpage = async ({
   params,
@@ -14,15 +10,14 @@ const BirthDayBookDetailpage = async ({
   params: Promise<{ isbn?: number }>;
 }) => {
   const { isbn } = await params;
-  const suspenseResource = fetchCsvBookDataSuspense(isbn);
+  const bookData = await getBookDetail(isbn || 0);
+
   return (
     <>
       <BookHeaderHelper bookData={undefined} isbn={isbn!} />
       <main className="flex size-full flex-1 items-center gap-8">
         <Suspense fallback={<LoadingSpinner className="h-[50vw] w-full" />}>
-          <BookDetail<CsvSuspenseResource>
-            suspenseResource={suspenseResource}
-          />
+          <BookDetail bookData={bookData} />
         </Suspense>
       </main>
     </>
@@ -30,39 +25,3 @@ const BirthDayBookDetailpage = async ({
 };
 
 export default BirthDayBookDetailpage;
-
-export type CsvSuspenseResource = {
-  read: () => CSVBook[];
-};
-const fetchCsvBookDataSuspense = (isbn?: number): CsvSuspenseResource => {
-  let data: CSVBook[] | undefined;
-  let promise: Promise<CSVBook[] | undefined>;
-  return {
-    read: () => {
-      if (data) return data;
-      if (!promise)
-        promise = fetchCsvData(isbn).then((result) => (data = result));
-      throw promise;
-    },
-  };
-};
-
-const fetchCsvData = async (isbn?: number) => {
-  if (!isbn) throw new Error("ISBN is required");
-  try {
-    const { publicRuntimeConfig } = getConfig();
-    const baseUrl = publicRuntimeConfig.VERCEL_PROJECT_PRODUCTION_URL;
-    const response = await fetch(`${baseUrl}/api/book?isbn=` + isbn, {
-      cache: "force-cache",
-      next: { revalidate: 86400, tags: [isbn.toString()] },
-    });
-    if (!response.ok) throw new Error("Failed to fetch data");
-    const data = await response.json();
-    const keys = Object.keys(data.data);
-    const parseData: CSVBook[] = keys.map((key) => data.data[key]);
-    return parseData;
-  } catch (error) {
-    console.error("Error fetching CSV data:", error);
-    throw error;
-  }
-};

--- a/app/(client)/(backButtonHeader)/birth-day/[isbn]/page.tsx
+++ b/app/(client)/(backButtonHeader)/birth-day/[isbn]/page.tsx
@@ -1,14 +1,18 @@
-import React, { Suspense } from "react";
-import BookHeaderHelper from "../../book/[isbn]/BookHeaderHelper";
+import BookDetail from "@/components/bookDetail/BookDetail";
 import LoadingSpinner from "@/components/common/LoadingSpinner";
 import { CSVBook } from "@/types/api";
-import BookDetail from "@/components/bookDetail/BookDetail";
 import getConfig from "next/config";
+import { Suspense } from "react";
+import BookHeaderHelper from "../../book/[isbn]/BookHeaderHelper";
 
 export const dynamic = "force-static";
 export const revalidate = 86400; // 캐시를 너무 오래 저장하면 더 중요한 캐시 정보(getBirthdayBook 함수처럼 무거운거)가 제거될 수 있으므로 생일도서가 변경되는 24시간만 유효하도록 설정함
 
-const BirthDayBookDetailpage = async ({ params }: { params: Promise<{ isbn?: number }> }) => {
+const BirthDayBookDetailpage = async ({
+  params,
+}: {
+  params: Promise<{ isbn?: number }>;
+}) => {
   const { isbn } = await params;
   const suspenseResource = fetchCsvBookDataSuspense(isbn);
   return (
@@ -16,7 +20,9 @@ const BirthDayBookDetailpage = async ({ params }: { params: Promise<{ isbn?: num
       <BookHeaderHelper bookData={undefined} isbn={isbn!} />
       <main className="flex size-full flex-1 items-center gap-8">
         <Suspense fallback={<LoadingSpinner className="h-[50vw] w-full" />}>
-          <BookDetail<CsvSuspenseResource> suspenseResource={suspenseResource} />
+          <BookDetail<CsvSuspenseResource>
+            suspenseResource={suspenseResource}
+          />
         </Suspense>
       </main>
     </>
@@ -34,7 +40,8 @@ const fetchCsvBookDataSuspense = (isbn?: number): CsvSuspenseResource => {
   return {
     read: () => {
       if (data) return data;
-      if (!promise) promise = fetchCsvData(isbn).then((result) => (data = result));
+      if (!promise)
+        promise = fetchCsvData(isbn).then((result) => (data = result));
       throw promise;
     },
   };

--- a/app/(client)/(backButtonHeader)/book/[isbn]/page.tsx
+++ b/app/(client)/(backButtonHeader)/book/[isbn]/page.tsx
@@ -1,23 +1,32 @@
-import React, { Suspense } from "react";
-import BookHeaderHelper from "./BookHeaderHelper";
-import { KaKaoBookResponse } from "@/types/api";
-import { handleFetchKaKaoData } from "@/function/common";
-import BookDetail from "@/components/bookDetail/BookDetail";
 import LoadingSpinner from "@/components/common/LoadingSpinner";
+import { handleFetchKaKaoData } from "@/function/common";
+import { KaKaoBookResponse } from "@/types/api";
+import { Suspense } from "react";
+import BookHeaderHelper from "./BookHeaderHelper";
+import BookDetailCsv from "@/components/bookDetail/BookDetailCsv";
 
 export const dynamic = "force-static";
 export const revalidate = 86400; // 24시간 동안 캐시 유지
 
-const BookDetailpage = async ({ params }: { params: Promise<{ isbn: number }> }) => {
+const BookDetailpage = async ({
+  params,
+}: {
+  params: Promise<{ isbn: number }>;
+}) => {
   const { isbn } = await params;
   const suspenseResource = fetchKaKaoBookSuspense(isbn);
 
   return (
     <>
-      <BookHeaderHelperContainer suspenseResource={suspenseResource} isbn={isbn} />
+      <BookHeaderHelperContainer
+        suspenseResource={suspenseResource}
+        isbn={isbn}
+      />
       <main className="flex size-full flex-1 items-center gap-8">
         <Suspense fallback={<LoadingSpinner className="h-[80vw] w-full" />}>
-          <BookDetail<KakaoSuspenseResource> suspenseResource={suspenseResource} />
+          <BookDetailCsv<KakaoSuspenseResource>
+            suspenseResource={suspenseResource}
+          />
         </Suspense>
       </main>
     </>
@@ -38,7 +47,10 @@ const fetchKaKaoBookSuspense = (isbn?: number): KakaoSuspenseResource => {
   return {
     read: () => {
       if (data) return data;
-      if (!promise) promise = handleFetchKaKaoData(isbn?.toString(), "isbn").then((result) => (data = result));
+      if (!promise)
+        promise = handleFetchKaKaoData(isbn?.toString(), "isbn").then(
+          (result) => (data = result)
+        );
       throw promise;
     },
   };

--- a/app/(client)/(exploreHeader)/explore/publisher/components/PublisherGridItem.tsx
+++ b/app/(client)/(exploreHeader)/explore/publisher/components/PublisherGridItem.tsx
@@ -1,22 +1,32 @@
 import PublisherPortrait from "@/components/publisherProfile/PublisherPortrait";
-import React from "react";
 
 type Props = {
   className?: string;
   publisherName: string;
-  imageUrl: string;
+  imageUrl?: string;
   instagramId: string;
 };
-const PublisherGridItem = ({ className, publisherName, imageUrl, instagramId, ...props }: Readonly<Props>) => {
+const PublisherGridItem = ({
+  className,
+  publisherName,
+  imageUrl,
+  instagramId,
+  ...props
+}: Readonly<Props>) => {
   return (
-    <div className={`relative flex size-full flex-col overflow-hidden ${className || ""}`} {...props}>
-      {imageUrl ? (
-        <PublisherPortrait className="mb-3" imageUrl={imageUrl} />
-      ) : (
-        <div className="aspect-square rounded-full bg-[#FFFFFFD9] shadow-[0_0_var(--client-layout-margin)_rgba(0,0,0,0.12)]"></div>
-      )}
-      <p className="line-clamp-1 text-center text-sm">{publisherName || "출판사 이름"}</p>
-      <p className="line-clamp-1 text-center text-xs text-[var(--sub-color)]">{instagramId || "인스타그램 아이디"}</p>
+    <div
+      className={`relative flex size-full flex-col overflow-hidden ${
+        className || ""
+      }`}
+      {...props}
+    >
+      <PublisherPortrait className="mb-3" imageUrl={imageUrl} />
+      <p className="line-clamp-1 text-center text-sm">
+        {publisherName || "출판사 이름"}
+      </p>
+      <p className="line-clamp-1 text-center text-xs text-[var(--sub-color)]">
+        {instagramId || "인스타그램 아이디"}
+      </p>
     </div>
   );
 };

--- a/app/(client)/(exploreHeader)/explore/publisher/page.tsx
+++ b/app/(client)/(exploreHeader)/explore/publisher/page.tsx
@@ -6,6 +6,8 @@ import PublisherFilterController from "./components/publisherFilterController/Pu
 
 const PublisherPage = async () => {
   const initialData = await getPublishers();
+  console.log(initialData);
+  
   return (
     <main className="relative flex size-full flex-col items-center">
       <PublisherPageDataProvider initialData={{initialData}}>
@@ -15,7 +17,7 @@ const PublisherPage = async () => {
             <Link href={`/publisher/${item.id}`} key={item.id}>
               <PublisherGridItem
                 key={item.id}
-                imageUrl={item.logo || "/default-image.jpg"}
+                imageUrl={item.logo}
                 instagramId="@testasddfsdaf"
                 publisherName="asdfsdasfd"
               />

--- a/app/(client)/(exploreHeader)/explore/publisher/page.tsx
+++ b/app/(client)/(exploreHeader)/explore/publisher/page.tsx
@@ -1,19 +1,21 @@
-import PublisherGridItem from "./components/PublisherGridItem";
+import { getPublishers } from "@/function/get/client";
 import Link from "next/link";
+import PublisherGridItem from "./components/PublisherGridItem";
 import PublisherPageDataProvider from "./components/PublisherPageDataProvider";
 import PublisherFilterController from "./components/publisherFilterController/PublisherFilterController";
 
-const PublisherPage = () => {
+const PublisherPage = async () => {
+  const initialData = await getPublishers();
   return (
     <main className="relative flex size-full flex-col items-center">
-      <PublisherPageDataProvider initialData={{}}>
+      <PublisherPageDataProvider initialData={{initialData}}>
         <PublisherFilterController />
         <section className="mt-14 grid size-full grid-cols-3 gap-2 p-9">
-          {[...new Array(30)].map((_item, index) => (
-            <Link href={`/publisher/${index}`} key={index}>
+          {initialData.items.map((item) => (
+            <Link href={`/publisher/${item.id}`} key={item.id}>
               <PublisherGridItem
-                key={index}
-                imageUrl="https://s3-alpha-sig.figma.com/img/d0e2/5bb2/de40eee98c72f7a09314e260baa500a0?Expires=1744588800&Key-Pair-Id=APKAQ4GOSFWCW27IBOMQ&Signature=iPBj-JFOKN~02lRr3C1SoNM0vmqmoWgGQ~~HO8V6F80ok2YjsJr4oD-nFnZQWTdo2vS5cY-r5WxRQDCTF5B~fxukoXy7mRvq-JudRbf8fWsfak2NJ0yeGXO5MOQMfVgP46GTmJjw98fBdNUZFoQuH103lzBgcdYGOtKRddg9CckUF5~WQqPo7ivrKl7RG0gCdMKkIDAI~JaLH3kGGiT0xAE~TMZs373K9qiuC6zzweO9KgSar5DddyMvIinPT1182v-nCt0Xrv6EUQ0MKWtkAQdji09S3Swg0f9X965u9lUB34osEJyHlYgjvPe6iviTMjbf-4~H0sMyTaQXzB5l0w__"
+                key={item.id}
+                imageUrl={item.logo || "/default-image.jpg"}
                 instagramId="@testasddfsdaf"
                 publisherName="asdfsdasfd"
               />

--- a/app/(client)/(exploreHeader)/explore/publisher/page.tsx
+++ b/app/(client)/(exploreHeader)/explore/publisher/page.tsx
@@ -18,8 +18,8 @@ const PublisherPage = async () => {
               <PublisherGridItem
                 key={item.id}
                 imageUrl={item.logo}
-                instagramId="@testasddfsdaf"
-                publisherName="asdfsdasfd"
+                instagramId={item.urls[0]?.url || ""}
+                publisherName={item.name}
               />
             </Link>
           ))}

--- a/app/(client)/(homeHeader)/components/mainBookSlide/MainBookSlide.tsx
+++ b/app/(client)/(homeHeader)/components/mainBookSlide/MainBookSlide.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import LoadingSpinner from "@/components/common/LoadingSpinner";
+import { getBirthdayBooks } from "@/function/get/client";
+import { useQuery } from "@tanstack/react-query";
 import {
   HTMLAttributes,
   useEffect,
@@ -11,18 +13,21 @@ import {
 import ReactConfetti from "react-confetti";
 import BookDescription from "./BookDescription";
 import MainBookSlideContainer from "./MainBookSlideContainer";
-import { getBirthdayBooks } from "@/function/get/client";
 
-type Props = { className?: string } & HTMLAttributes<HTMLDivElement>;
+type Props = {
+  className?: string;
+} & HTMLAttributes<HTMLDivElement>;
 
 const MainBookSlide = ({ className, ...props }: Readonly<Props>) => {
-  const today = new Date().toISOString().split("T")[0];
-  const data = getBirthdayBooks(today);
-  console.log(data);
-
   const sectionRef = useRef<HTMLDivElement>(null);
   const [size, setSize] = useState({ width: 0, height: 0 });
   const [confettiWind, setConfettiWind] = useState<number>(0);
+  const today = new Date().toISOString().split("T")[0];
+
+  const { data } = useQuery({
+    queryKey: ["today"],
+    queryFn: () => getBirthdayBooks(today),
+  });
 
   //전체 크기 조정용
   useLayoutEffect(() => {
@@ -68,11 +73,9 @@ const MainBookSlide = ({ className, ...props }: Readonly<Props>) => {
         createdAt={new Date()}
         className="z-10 px-[var(--client-layout-margin)]"
       />
-      {status === "success" ? (
+      {data?.items ? (
         <MainBookSlideContainer
-          books={
-            data ? data.pages.flatMap((page) => page.items).slice(0, 6) : []
-          }
+          books={data.items}
           setConfettiWind={setConfettiWind}
         />
       ) : (

--- a/app/(client)/(homeHeader)/components/mainBookSlide/MainBookSlide.tsx
+++ b/app/(client)/(homeHeader)/components/mainBookSlide/MainBookSlide.tsx
@@ -1,4 +1,5 @@
 "use client";
+
 import LoadingSpinner from "@/components/common/LoadingSpinner";
 import {
   HTMLAttributes,
@@ -9,11 +10,16 @@ import {
 } from "react";
 import ReactConfetti from "react-confetti";
 import BookDescription from "./BookDescription";
+import MainBookSlideContainer from "./MainBookSlideContainer";
+import { getBirthdayBooks } from "@/function/get/client";
 
 type Props = { className?: string } & HTMLAttributes<HTMLDivElement>;
 
 const MainBookSlide = ({ className, ...props }: Readonly<Props>) => {
-  // const { data, status } = useGetBirthDayBooks();
+  const today = new Date().toISOString().split("T")[0];
+  const data = getBirthdayBooks(today);
+  console.log(data);
+
   const sectionRef = useRef<HTMLDivElement>(null);
   const [size, setSize] = useState({ width: 0, height: 0 });
   const [confettiWind, setConfettiWind] = useState<number>(0);
@@ -62,16 +68,16 @@ const MainBookSlide = ({ className, ...props }: Readonly<Props>) => {
         createdAt={new Date()}
         className="z-10 px-[var(--client-layout-margin)]"
       />
-      {/* {status === "success" ? (
+      {status === "success" ? (
         <MainBookSlideContainer
           books={
             data ? data.pages.flatMap((page) => page.items).slice(0, 6) : []
           }
           setConfettiWind={setConfettiWind}
         />
-      ) : ( */}
-      <LoadingSpinner className="h-[30vw] w-full" />
-      {/* )} */}
+      ) : (
+        <LoadingSpinner className="h-[30vw] w-full" />
+      )}
     </section>
   );
 };

--- a/app/(client)/(homeHeader)/components/mainBookSlide/MainBookSlideContainer.tsx
+++ b/app/(client)/(homeHeader)/components/mainBookSlide/MainBookSlideContainer.tsx
@@ -31,7 +31,10 @@ const MainBookSlideContainer = ({
   const slideContainerRef = useRef<HTMLDivElement>(null);
   const [booksData, setBooksData] = useState<Array<BookDto> | undefined>(books);
   const [isMobileState, setIsMobileState] = useState(false);
-
+  
+  useEffect(() => {
+    setBooksData(books);
+  }, [books]);
   //슬라이드 뷰 크기 조정용
   useLayoutEffect(() => {
     const slideViewUpdateSize = () => {

--- a/app/(client)/(homeHeader)/components/mainBookSlide/MainBookSlideContainer.tsx
+++ b/app/(client)/(homeHeader)/components/mainBookSlide/MainBookSlideContainer.tsx
@@ -31,7 +31,7 @@ const MainBookSlideContainer = ({
   const slideContainerRef = useRef<HTMLDivElement>(null);
   const [booksData, setBooksData] = useState<Array<BookDto> | undefined>(books);
   const [isMobileState, setIsMobileState] = useState(false);
-  
+
   useEffect(() => {
     setBooksData(books);
   }, [books]);
@@ -49,14 +49,14 @@ const MainBookSlideContainer = ({
 
   const slideLeftHandler = () => {
     setBooksData((prev) => {
-      if (!prev) return prev;
+      if (!prev || prev.length === 0) return prev;
       return [...prev.slice(1), prev[0]];
     });
     setConfettiWind(-0.1);
   };
   const slideRightHandler = () => {
     setBooksData((prev) => {
-      if (!prev) return prev;
+      if (!prev || prev.length === 0) return prev;
       return [prev[prev.length - 1], ...prev.slice(0, prev.length - 1)];
     });
     setConfettiWind(0.1);

--- a/app/(client)/(homeHeader)/components/todayLibrary/SlideIndicator.tsx
+++ b/app/(client)/(homeHeader)/components/todayLibrary/SlideIndicator.tsx
@@ -14,8 +14,6 @@ const SlideIndicator = ({
   setCurrentPage,
   ...props
 }: Readonly<Props>) => {
-  console.log(pageCount, currentPage);
-
   return (
     <div
       className={`relative flex w-full flex-row items-center justify-center gap-1 ${

--- a/app/(client)/(homeHeader)/page.tsx
+++ b/app/(client)/(homeHeader)/page.tsx
@@ -9,7 +9,7 @@ export const dynamic = "force-dynamic";
 const Home = () => {
   return (
     <main className="relative flex size-full flex-col items-center py-5">
-      <MainBookSlideContainer />
+      <MainBookSlide className="mb-12" />
       <Suspense fallback={<LoadingSpinner className="w-full" />}>
         <DiscoveryDemo />
       </Suspense>
@@ -22,17 +22,3 @@ const Home = () => {
 };
 
 export default Home;
-
-const MainBookSlideContainer = async () => {
-  return <MainBookSlide className="mb-12" />;
-};
-
-// const MainBookSlideContainer = async () => {
-//   const data = await getBirthdayBook();
-//   return (
-//     <>
-//       <BirthDayBookSaveHelper books={data} />
-//       <MainBookSlideDemo books={data.slice(0, 6)} />
-//     </>
-//   );
-// };

--- a/app/(client)/(homeHeader)/page.tsx
+++ b/app/(client)/(homeHeader)/page.tsx
@@ -1,9 +1,7 @@
 import LoadingSpinner from "@/components/common/LoadingSpinner";
 import DiscoveryDemo from "@/components/discovery/DiscoveryDemo";
-import getBirthdayBook from "@/function/server/getBirtdayBook";
 import { Suspense } from "react";
-import BirthDayBookSaveHelper from "./components/BirthDayBookSaveHelper";
-import MainBookSlideDemo from "./components/mainBookSlide/demo/MainBookSlideDemo";
+import MainBookSlide from "./components/mainBookSlide/MainBookSlide";
 import MainScheduleSlideDemo from "./components/mainScheduleSlide/MainScheduleSlideDemo";
 import TodayLibraryDemo from "./components/todayLibrary/TodayLibraryDemo";
 export const dynamic = "force-dynamic";
@@ -11,7 +9,6 @@ export const dynamic = "force-dynamic";
 const Home = () => {
   return (
     <main className="relative flex size-full flex-col items-center py-5">
-      {/* <MainBookSlide /> */}
       <MainBookSlideContainer />
       <Suspense fallback={<LoadingSpinner className="w-full" />}>
         <DiscoveryDemo />
@@ -26,17 +23,16 @@ const Home = () => {
 
 export default Home;
 
-// const MainBookSlideContainer = async () => {
-//   const data = await getBirtdayBook();
-//   return <MainBookSlide className="mb-12" books={data} />;
-// };
-
 const MainBookSlideContainer = async () => {
-  const data = await getBirthdayBook();
-  return (
-    <>
-      <BirthDayBookSaveHelper books={data} />
-      <MainBookSlideDemo books={data.slice(0, 6)} />
-    </>
-  );
+  return <MainBookSlide className="mb-12" />;
 };
+
+// const MainBookSlideContainer = async () => {
+//   const data = await getBirthdayBook();
+//   return (
+//     <>
+//       <BirthDayBookSaveHelper books={data} />
+//       <MainBookSlideDemo books={data.slice(0, 6)} />
+//     </>
+//   );
+// };

--- a/app/(client)/(homeHeader)/page.tsx
+++ b/app/(client)/(homeHeader)/page.tsx
@@ -1,8 +1,8 @@
 import LoadingSpinner from "@/components/common/LoadingSpinner";
-import DiscoveryDemo from "@/components/discovery/DiscoveryDemo";
+import Discovery from "@/components/discovery/Discovery";
 import { Suspense } from "react";
 import MainBookSlide from "./components/mainBookSlide/MainBookSlide";
-import MainScheduleSlideDemo from "./components/mainScheduleSlide/MainScheduleSlideDemo";
+import MainScheduleSlide from "./components/mainScheduleSlide/MainScheduleSlide";
 import TodayLibraryDemo from "./components/todayLibrary/TodayLibraryDemo";
 export const dynamic = "force-dynamic";
 
@@ -11,12 +11,12 @@ const Home = () => {
     <main className="relative flex size-full flex-col items-center py-5">
       <MainBookSlide className="mb-12" />
       <Suspense fallback={<LoadingSpinner className="w-full" />}>
-        <DiscoveryDemo />
+        <Discovery />
       </Suspense>
       <Suspense fallback={<LoadingSpinner className="w-full" />}>
         <TodayLibraryDemo />
       </Suspense>
-      <MainScheduleSlideDemo />
+      <MainScheduleSlide />
     </main>
   );
 };

--- a/components/bookDetail/BookDetail.tsx
+++ b/components/bookDetail/BookDetail.tsx
@@ -11,12 +11,15 @@ type Props<T extends CsvSuspenseResource | KakaoSuspenseResource> = {
   className?: string;
   suspenseResource: T;
 } & HTMLAttributes<HTMLDivElement>;
-const BookDetail = <T extends CsvSuspenseResource | KakaoSuspenseResource>({
+const BookDetail = async <
+  T extends CsvSuspenseResource | KakaoSuspenseResource
+>({
   className,
   suspenseResource,
   ...props
 }: Readonly<Props<T>>) => {
   const result = suspenseResource.read();
+  // const bookContents =  await getBookContents(result[0].isbn || result.documents[0].isbn);
   const bookData = Array.isArray(result)
     ? {
         thumbnail: result[0].IMAGE_URL,
@@ -63,7 +66,7 @@ const BookDetail = <T extends CsvSuspenseResource | KakaoSuspenseResource>({
         <RecommandedItem
           imageUrl="https://s3-alpha-sig.figma.com/img/8d4f/4b13/868fb4811d7171eef83e5a8d8988ba13?Expires=1740960000&Key-Pair-Id=APKAQ4GOSFWCW27IBOMQ&Signature=ORxF1blpY9piMcDNWkmkCr~abQC~WhkmoV7bR8-1ZScEsgdDOEC~8K-fqVZWqkV9CCAm9yq5kkVK41L-FC8CaWHMeg6-jXLoMccBB0h3L1UDZNW94CxQGXq5eaniifhL65J3yI-yzkLhNthlH7kj2vrEZSg3GNDkOdnznkIaG6VqGoOfiPwqKIsJpo0oDNGmYpaFecaKCtQwvXD43jaZXmvwL1jIXwFuNrG7wTJkvnEYNf8CkWfCTxBExvqEiqwaj94XxeOpGA1wWWAmyPVGqG1Ngm2sifZWw3XkNGnZs0FDqd25Wo0eZHpTRAG7nFIzAq81iB2WBEz~prRFDvoNnw__"
           sourceName="유튜브"
-          sourceUrl="ㅁㄴㅇㄹ"
+          sourceUrl="https://www.youtube.com/watch?v=example"
           title="fasdfasdfasdfasdsdfasdfasdfasdfasdfasdfasdfaasdsdfasdfasdfasdfasdfasdfasdfassdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfafasd"
         />
       </section>

--- a/components/bookDetail/BookDetail.tsx
+++ b/components/bookDetail/BookDetail.tsx
@@ -1,67 +1,39 @@
-import { CsvSuspenseResource } from "@/app/(client)/(backButtonHeader)/birth-day/[isbn]/page";
-import { KakaoSuspenseResource } from "@/app/(client)/(backButtonHeader)/book/[isbn]/page";
-import { HTMLAttributes } from "react";
+import { Detail } from "@/types/dto";
 import BookDetailImageSection from "./BookDetailImageSection";
 import BookDetailSection from "./BookDetailSection";
 import BookTitleSection from "./BookTitleSection";
 import ReadersReview from "./ReadersReview";
-import RecommandedItem from "./RecommandedItem";
 
-type Props<T extends CsvSuspenseResource | KakaoSuspenseResource> = {
+interface BookDetailProps {
+  bookData: Detail;
   className?: string;
-  suspenseResource: T;
-} & HTMLAttributes<HTMLDivElement>;
-const BookDetail = async <
-  T extends CsvSuspenseResource | KakaoSuspenseResource
->({
-  className,
-  suspenseResource,
-  ...props
-}: Readonly<Props<T>>) => {
-  const result = suspenseResource.read();
-  // const bookContents =  await getBookContents(result[0].isbn || result.documents[0].isbn);
-  const bookData = Array.isArray(result)
-    ? {
-        thumbnail: result[0].IMAGE_URL,
-        datetime: result[0].TWO_PBLICTE_DE,
-        title: result[0].TITLE_NM,
-        url: "",
-        authors: result[0].AUTHR_NM.split(", "),
-        publisher: result[0].PUBLISHER_NM,
-        contents: result[0].BOOK_INTRCN_CN,
-      }
-    : result.documents[0];
-
-  const kstBirthDay = new Date(
-    new Date(bookData?.datetime).getTime() + 9 * 60 * 60 * 1000
-  );
-
+}
+const BookDetail = ({ bookData, className }: BookDetailProps) => {
   return (
     <div
       className={`relative flex size-full flex-col gap-7 px-[var(--client-layout-margin)] ${
         className || ""
       }`}
-      {...props}
     >
       <BookDetailImageSection
-        imageUrl={bookData?.thumbnail}
-        birthDay={kstBirthDay}
+        imageUrl={bookData.titleImage}
+        birthDay={bookData.publishedDate}
         className="mt-6"
       />
       <BookTitleSection
         bookName={bookData?.title || "책 이름(정보 미제공)"}
-        birthDayDate={kstBirthDay}
-        url={bookData?.url}
-        author={bookData?.authors.join(", ") || "저자 이름(정보 미제공)"}
+        birthDayDate={bookData.publishedDate}
+        url={bookData.detailUrl}
+        author={bookData?.authorList.join(", ") || "저자 이름(정보 미제공)"}
       />
       <BookDetailSection
-        author={bookData?.authors.join(", ") || "저자 이름(정보 미제공)"}
-        pulisher={bookData?.publisher || "출판사(정보 미제공)"}
-        description={bookData?.contents || "책 소개(정보 미제공)"}
-        viewMoreUrl={bookData?.url}
+        author={bookData?.authorList.join(", ") || "저자 이름(정보 미제공)"}
+        pulisher={bookData?.publisher.name || "출판사(정보 미제공)"}
+        description={bookData?.summary || "책 소개(정보 미제공)"}
+        viewMoreUrl={bookData?.detailUrl}
         className="mb-10"
       />
-      <section>
+      {/* <section>
         <h2 className="text-lg font-bold">추천 콘텐츠</h2>
         <RecommandedItem
           imageUrl="https://s3-alpha-sig.figma.com/img/8d4f/4b13/868fb4811d7171eef83e5a8d8988ba13?Expires=1740960000&Key-Pair-Id=APKAQ4GOSFWCW27IBOMQ&Signature=ORxF1blpY9piMcDNWkmkCr~abQC~WhkmoV7bR8-1ZScEsgdDOEC~8K-fqVZWqkV9CCAm9yq5kkVK41L-FC8CaWHMeg6-jXLoMccBB0h3L1UDZNW94CxQGXq5eaniifhL65J3yI-yzkLhNthlH7kj2vrEZSg3GNDkOdnznkIaG6VqGoOfiPwqKIsJpo0oDNGmYpaFecaKCtQwvXD43jaZXmvwL1jIXwFuNrG7wTJkvnEYNf8CkWfCTxBExvqEiqwaj94XxeOpGA1wWWAmyPVGqG1Ngm2sifZWw3XkNGnZs0FDqd25Wo0eZHpTRAG7nFIzAq81iB2WBEz~prRFDvoNnw__"
@@ -69,7 +41,7 @@ const BookDetail = async <
           sourceUrl="https://www.youtube.com/watch?v=example"
           title="fasdfasdfasdfasdsdfasdfasdfasdfasdfasdfasdfaasdsdfasdfasdfasdfasdfasdfasdfassdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfafasd"
         />
-      </section>
+      </section> */}
       <ReadersReview />
     </div>
   );

--- a/components/bookDetail/BookDetailCsv.tsx
+++ b/components/bookDetail/BookDetailCsv.tsx
@@ -1,0 +1,77 @@
+import { KakaoSuspenseResource } from "@/app/(client)/(backButtonHeader)/book/[isbn]/page";
+import { HTMLAttributes } from "react";
+import BookDetailImageSection from "./BookDetailImageSection";
+import BookDetailSection from "./BookDetailSection";
+import BookTitleSection from "./BookTitleSection";
+import ReadersReview from "./ReadersReview";
+import RecommandedItem from "./RecommandedItem";
+import { CsvSuspenseResource } from "@/app/(client)/(backButtonHeader)/birth-day/[isbn]/Before";
+
+type Props<T extends CsvSuspenseResource | KakaoSuspenseResource> = {
+  className?: string;
+  suspenseResource: T;
+} & HTMLAttributes<HTMLDivElement>;
+const BookDetailCsv = async <
+  T extends CsvSuspenseResource | KakaoSuspenseResource
+>({
+  className,
+  suspenseResource,
+  ...props
+}: Readonly<Props<T>>) => {
+  const result = suspenseResource.read();
+  const bookData = Array.isArray(result)
+    ? {
+        thumbnail: result[0].IMAGE_URL,
+        datetime: result[0].TWO_PBLICTE_DE,
+        title: result[0].TITLE_NM,
+        url: "",
+        authors: result[0].AUTHR_NM.split(", "),
+        publisher: result[0].PUBLISHER_NM,
+        contents: result[0].BOOK_INTRCN_CN,
+      }
+    : result.documents[0];
+
+  const kstBirthDay = new Date(
+    new Date(bookData?.datetime).getTime() + 9 * 60 * 60 * 1000
+  );
+
+  return (
+    <div
+      className={`relative flex size-full flex-col gap-7 px-[var(--client-layout-margin)] ${
+        className || ""
+      }`}
+      {...props}
+    >
+      <BookDetailImageSection
+        imageUrl={bookData?.thumbnail}
+        birthDay={kstBirthDay}
+        className="mt-6"
+      />
+      <BookTitleSection
+        bookName={bookData?.title || "책 이름(정보 미제공)"}
+        birthDayDate={kstBirthDay}
+        url={bookData?.url}
+        author={bookData?.authors.join(", ") || "저자 이름(정보 미제공)"}
+      />
+      <BookDetailSection
+        author={bookData?.authors.join(", ") || "저자 이름(정보 미제공)"}
+        pulisher={bookData?.publisher || "출판사(정보 미제공)"}
+        description={bookData?.contents || "책 소개(정보 미제공)"}
+        viewMoreUrl={bookData?.url}
+        className="mb-10"
+      />
+      <section>
+        <h2 className="text-lg font-bold">추천 콘텐츠</h2>
+        <RecommandedItem
+          imageUrl="https://s3-alpha-sig.figma.com/img/8d4f/4b13/868fb4811d7171eef83e5a8d8988ba13?Expires=1740960000&Key-Pair-Id=APKAQ4GOSFWCW27IBOMQ&Signature=ORxF1blpY9piMcDNWkmkCr~abQC~WhkmoV7bR8-1ZScEsgdDOEC~8K-fqVZWqkV9CCAm9yq5kkVK41L-FC8CaWHMeg6-jXLoMccBB0h3L1UDZNW94CxQGXq5eaniifhL65J3yI-yzkLhNthlH7kj2vrEZSg3GNDkOdnznkIaG6VqGoOfiPwqKIsJpo0oDNGmYpaFecaKCtQwvXD43jaZXmvwL1jIXwFuNrG7wTJkvnEYNf8CkWfCTxBExvqEiqwaj94XxeOpGA1wWWAmyPVGqG1Ngm2sifZWw3XkNGnZs0FDqd25Wo0eZHpTRAG7nFIzAq81iB2WBEz~prRFDvoNnw__"
+          sourceName="유튜브"
+          sourceUrl="https://www.youtube.com/watch?v=example"
+          title="fasdfasdfasdfasdsdfasdfasdfasdfasdfasdfasdfaasdsdfasdfasdfasdfasdfasdfasdfassdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfafasd"
+        />
+      </section>
+      <ReadersReview />
+    </div>
+  );
+};
+
+export default BookDetailCsv;

--- a/components/bookDetail/BookDetailImageSection.tsx
+++ b/components/bookDetail/BookDetailImageSection.tsx
@@ -5,7 +5,9 @@ import EmptyImage from "../common/EmptyImage";
 
 type Props = { className?: string; imageUrl?: string; birthDay?: Date } & HTMLAttributes<HTMLDivElement>;
 const BookDetailImageSection = ({ className, imageUrl, birthDay, ...props }: Readonly<Props>) => {
-  const isBirthday = birthDay?.getDate() === new Date().getDate() && birthDay.getMonth() === new Date().getMonth();
+  const birthdayDate = new Date(birthDay || "");
+
+  const isBirthday = birthdayDate?.getDate() === new Date().getDate() && birthdayDate.getMonth() === new Date().getMonth();
   return (
     <section
       className={`relative mx-auto flex aspect-[3/4] size-full max-w-[163px] items-center justify-center ${

--- a/components/bookDetail/BookTitleSection.tsx
+++ b/components/bookDetail/BookTitleSection.tsx
@@ -16,6 +16,8 @@ const BookTitleSection = ({
   author,
   ...props
 }: Readonly<Props>) => {
+  const birthday = new Date(birthDayDate || "");
+  
   return (
     <section
       className={`relative flex size-full flex-col gap-1 ${className || ""}`}
@@ -27,8 +29,8 @@ const BookTitleSection = ({
       </span>
       <p className="flex flex-row items-start gap-1 text-xs text-[var(--highlight-color)]">
         <BirthDayCakeIcon className="w-3" />
-        {birthDayDate
-          ? formatDateToKorean(birthDayDate)
+        {birthday
+          ? formatDateToKorean(birthday)
           : "정보가 제공되지 않았습니다"}
       </p>
       {/* <div className="flex flex-row gap-2 text-sm text-[var(--sub-color)]">

--- a/components/discovery/Discovery.tsx
+++ b/components/discovery/Discovery.tsx
@@ -4,15 +4,6 @@ import Link from "next/link";
 import React, { HTMLAttributes } from "react";
 import CommonPillButton from "../common/CommonPillButton";
 import EmptyImage from "../common/EmptyImage";
-import DiscoveryItem from "./DiscoveryItem";
-
-enum ContentsType {
-  "Youtube" = "유튜브",
-  "Homepage" = "홈페이지",
-  "Blog" = "블로그",
-  "Link" = "링크",
-  "Profile" = "프로필",
-}
 
 type Props = { className?: string } & HTMLAttributes<HTMLDivElement>;
 const Discovery = async ({ className, ...props }: Readonly<Props>) => {
@@ -51,14 +42,14 @@ const Discovery = async ({ className, ...props }: Readonly<Props>) => {
           {dailyDiscoveryData.map(
             (item, index) =>
               index > 0 &&
-              index < 3 && (
+              index < 4 && (
                 <React.Fragment key={item.id}>
-                  <DiscoveryItem
-                    contentType={ContentsType[item.urls[0].type] || "기타"}
-                    title={item.title || ""}
+                  {/* <DiscoveryItem
+                    contentType={ContentsType[item.urls[0].url] || "기타"}
+                    title={item. || ""}
                     imageUrl={item.image}
-                  />
-                  {index < 3 - 1 && <div className="border-b" />}
+                  /> */}
+                  {index < 3 && <div className="border-b" />}
                 </React.Fragment>
               )
           )}

--- a/components/discovery/Discovery.tsx
+++ b/components/discovery/Discovery.tsx
@@ -1,4 +1,5 @@
 import fetchDailyDiscovery from "@/function/fetch/fetchDailyDiscovery";
+import { ContentsType } from "@/types/dto";
 import Image from "next/image";
 import Link from "next/link";
 import React, { HTMLAttributes } from "react";
@@ -8,13 +9,6 @@ import DiscoveryItem from "./DiscoveryItem";
 
 type Props = { className?: string } & HTMLAttributes<HTMLDivElement>;
 
-enum ContentsType {
-  "Youtube" = "유튜브",
-  "Homepage" = "홈페이지",
-  "Blog" = "블로그",
-  "Link" = "링크",
-  "Profile" = "프로필",
-}
 const Discovery = async ({ className, ...props }: Readonly<Props>) => {
   const dailyDiscoveryData = await fetchDailyDiscovery();
   const hasDiscovery = dailyDiscoveryData && dailyDiscoveryData.length > 0;
@@ -54,7 +48,11 @@ const Discovery = async ({ className, ...props }: Readonly<Props>) => {
               index < 4 && (
                 <React.Fragment key={item.id}>
                   <DiscoveryItem
-                    contentType={ContentsType[item.urls[index].type] || "기타"}
+                    contentType={
+                      item.urls && index < item.urls.length
+                        ? ContentsType[item.urls[index].type] || "기타"
+                        : "기타"
+                    }
                     title={item.title || ""}
                     imageUrl={item.image}
                   />

--- a/components/discovery/Discovery.tsx
+++ b/components/discovery/Discovery.tsx
@@ -4,8 +4,17 @@ import Link from "next/link";
 import React, { HTMLAttributes } from "react";
 import CommonPillButton from "../common/CommonPillButton";
 import EmptyImage from "../common/EmptyImage";
+import DiscoveryItem from "./DiscoveryItem";
 
 type Props = { className?: string } & HTMLAttributes<HTMLDivElement>;
+
+enum ContentsType {
+  "Youtube" = "유튜브",
+  "Homepage" = "홈페이지",
+  "Blog" = "블로그",
+  "Link" = "링크",
+  "Profile" = "프로필",
+}
 const Discovery = async ({ className, ...props }: Readonly<Props>) => {
   const dailyDiscoveryData = await fetchDailyDiscovery();
   const hasDiscovery = dailyDiscoveryData && dailyDiscoveryData.length > 0;
@@ -44,11 +53,11 @@ const Discovery = async ({ className, ...props }: Readonly<Props>) => {
               index > 0 &&
               index < 4 && (
                 <React.Fragment key={item.id}>
-                  {/* <DiscoveryItem
-                    contentType={ContentsType[item.urls[0].url] || "기타"}
-                    title={item. || ""}
+                  <DiscoveryItem
+                    contentType={ContentsType[item.urls[index].type] || "기타"}
+                    title={item.title || ""}
                     imageUrl={item.image}
-                  /> */}
+                  />
                   {index < 3 && <div className="border-b" />}
                 </React.Fragment>
               )

--- a/components/discovery/DiscoveryDemo.tsx
+++ b/components/discovery/DiscoveryDemo.tsx
@@ -1,17 +1,10 @@
+import { MOCK_CONTENTS } from "@/public/data/mock_content";
+import { ContentsType } from "@/types/dto";
 import Image from "next/image";
 import Link from "next/link";
 import React, { HTMLAttributes } from "react";
 import CommonPillButton from "../common/CommonPillButton";
 import DiscoveryItem from "./DiscoveryItem";
-import { MOCK_CONTENTS } from "@/public/data/mock_content";
-
-enum ContentsType {
-  "Youtube" = "유튜브",
-  "Homepage" = "홈페이지",
-  "Blog" = "블로그",
-  "Link" = "링크",
-  "Profile" = "프로필",
-}
 
 type Props = { className?: string } & HTMLAttributes<HTMLDivElement>;
 const DiscoveryDemo = async ({ className, ...props }: Readonly<Props>) => {
@@ -50,7 +43,7 @@ const DiscoveryDemo = async ({ className, ...props }: Readonly<Props>) => {
                     title={item.title || ""}
                     imageUrl={item.image}
                   />
-                  {index < 3  && <div className="border-b" />}
+                  {index < 3 && <div className="border-b" />}
                 </React.Fragment>
               )
           )}

--- a/components/publisherProfile/PublisherPortrait.tsx
+++ b/components/publisherProfile/PublisherPortrait.tsx
@@ -1,14 +1,49 @@
+'use client'
+
 import Image from "next/image";
+import { useState, useMemo } from "react";
 import EmptyImage from "../common/EmptyImage";
 
 type Props = {
   className?: string;
   imageUrl?: string;
 };
-const PublisherPortrait = ({ className, imageUrl, ...props }: Readonly<Props>) => {
+const PublisherPortrait = ({
+  className,
+  imageUrl,
+  ...props
+}: Readonly<Props>) => {
+  const [hasError, setHasError] = useState(false);
+
+  const isValidUrl = useMemo(() => {
+    if (!imageUrl) return false;
+    try {
+      new URL(imageUrl);
+      return true;
+    } catch {
+      return false;
+    }
+  }, [imageUrl]);
+
+  const shouldShowImage = isValidUrl && !hasError;
+
   return (
-    <div className={`relative aspect-square w-full overflow-hidden rounded-full ${className || ""}`} {...props}>
-      {imageUrl ? <Image alt="publisher" src={imageUrl} fill></Image> : <EmptyImage />}
+    <div
+      className={`relative aspect-square w-full overflow-hidden rounded-full ${
+        className || ""
+      }`}
+      {...props}
+    >
+      {shouldShowImage ? (
+        <Image
+          alt="publisher"
+          src={imageUrl!}
+          fill
+          onError={() => setHasError(true)}
+        />
+      ) : (
+        <EmptyImage />
+      )}
     </div>
   );
 };

--- a/function/fetch/fetchDailyDiscovery.ts
+++ b/function/fetch/fetchDailyDiscovery.ts
@@ -1,7 +1,7 @@
-import { ContentsDto, ListResponseContentsDto } from "@/types/dto";
+import { DisoveryContentsDto, ListResponseContentsDto } from "@/types/dto";
 import fetchWithTimeout from "./fetchWithTimeout";
 
-const fetchDailyDiscovery = async (): Promise<ContentsDto[]> => {
+const fetchDailyDiscovery = async (): Promise<DisoveryContentsDto[]> => {
   try {
     const response = await fetchWithTimeout(
       process.env.NEXT_PUBLIC_BACKEND_URL + "/contents/discovery",
@@ -11,7 +11,7 @@ const fetchDailyDiscovery = async (): Promise<ContentsDto[]> => {
     );
     if (response.ok) {
       const result: ListResponseContentsDto = await response.json();
-      return result.items;
+      return result.items || [];
     } else {
       throw new Error(response.statusText);
     }

--- a/function/fetch/fetchDailyDiscovery.ts
+++ b/function/fetch/fetchDailyDiscovery.ts
@@ -1,7 +1,7 @@
-import { DisoveryContentsDto, ListResponseContentsDto } from "@/types/dto";
+import { ContentsDto, ListResponseContentsDto } from "@/types/dto";
 import fetchWithTimeout from "./fetchWithTimeout";
 
-const fetchDailyDiscovery = async (): Promise<DisoveryContentsDto[]> => {
+const fetchDailyDiscovery = async (): Promise<ContentsDto[]> => {
   try {
     const response = await fetchWithTimeout(
       process.env.NEXT_PUBLIC_BACKEND_URL + "/contents/discovery",

--- a/function/get/admin.ts
+++ b/function/get/admin.ts
@@ -1,7 +1,7 @@
-import { getRequest } from "./commonGet";
+import { getRequestForAdmin } from "./commonGet";
 
-export const getAdminKakaoBooks = () => getRequest("/kakao-books");
+export const getAdminKakaoBooks = () => getRequestForAdmin("/kakao-books");
 
-export const getAdminViewLogs = () => getRequest("/book-view-logs");
+export const getAdminViewLogs = () => getRequestForAdmin("/book-view-logs");
 
-export const getAdminSearchLogs = () => getRequest("/book-search-logs");
+export const getAdminSearchLogs = () => getRequestForAdmin("/book-search-logs");

--- a/function/get/client.ts
+++ b/function/get/client.ts
@@ -6,3 +6,6 @@ export const getPublishers = () =>
 
 export const getBookContents = (isbn: string) =>
   getRequest<ListResponseContentsDto>(`books/${isbn}/contents`);
+
+export const getBirthdayBooks = (date: string) =>
+  getRequest<ListResponseContentsDto>(`books?page=0&limit=10&publishedDate=${date}&orderBy=PublishedDate&direction=desc`);

--- a/function/get/client.ts
+++ b/function/get/client.ts
@@ -1,4 +1,5 @@
 import {
+  Detail,
   ListResponseContentsDto,
   PageResponseBookDto,
   PageResponsePublisherDto,
@@ -13,5 +14,8 @@ export const getBookContents = (isbn: string) =>
 
 export const getBirthdayBooks = (date: string) =>
   getRequest<PageResponseBookDto>(
-    `/books?page=0&limit=10&publishedDate=${'2025-06-20'}&orderBy=PublishedDate&direction=desc`
+    `/books?page=0&limit=10&publishedDate=${"2025-06-20"}&orderBy=PublishedDate&direction=desc`
   );
+
+export const getBookDetail = (isbn: number) =>
+  getRequest<Detail>(`/books/{isbn}?isbn=${isbn}`);

--- a/function/get/client.ts
+++ b/function/get/client.ts
@@ -1,5 +1,8 @@
-import { PageResponsePublisherDto } from "@/types/dto";
+import { ListResponseContentsDto, PageResponsePublisherDto } from "@/types/dto";
 import { getRequest } from "./commonGet";
 
 export const getPublishers = () =>
   getRequest<PageResponsePublisherDto>("/publishers");
+
+export const getBookContents = (isbn: string) =>
+  getRequest<ListResponseContentsDto>(`books/${isbn}/contents`);

--- a/function/get/client.ts
+++ b/function/get/client.ts
@@ -13,5 +13,5 @@ export const getBookContents = (isbn: string) =>
 
 export const getBirthdayBooks = (date: string) =>
   getRequest<PageResponseBookDto>(
-    `/books?page=0&limit=10&publishedDate=${date}&orderBy=PublishedDate&direction=desc`
+    `/books?page=0&limit=10&publishedDate=${'2025-06-20'}&orderBy=PublishedDate&direction=desc`
   );

--- a/function/get/client.ts
+++ b/function/get/client.ts
@@ -13,5 +13,5 @@ export const getBookContents = (isbn: string) =>
 
 export const getBirthdayBooks = (date: string) =>
   getRequest<PageResponseBookDto>(
-    `/books?page=0&limit=10&publishedDate=2025-06-20&orderBy=PublishedDate&direction=desc`
+    `/books?page=0&limit=10&publishedDate=${date}&orderBy=PublishedDate&direction=desc`
   );

--- a/function/get/client.ts
+++ b/function/get/client.ts
@@ -1,0 +1,5 @@
+import { PageResponsePublisherDto } from "@/types/dto";
+import { getRequest } from "./commonGet";
+
+export const getPublishers = () =>
+  getRequest<PageResponsePublisherDto>("/publishers");

--- a/function/get/client.ts
+++ b/function/get/client.ts
@@ -1,4 +1,8 @@
-import { ListResponseContentsDto, PageResponsePublisherDto } from "@/types/dto";
+import {
+  ListResponseContentsDto,
+  PageResponseBookDto,
+  PageResponsePublisherDto,
+} from "@/types/dto";
 import { getRequest } from "./commonGet";
 
 export const getPublishers = () =>
@@ -8,4 +12,6 @@ export const getBookContents = (isbn: string) =>
   getRequest<ListResponseContentsDto>(`books/${isbn}/contents`);
 
 export const getBirthdayBooks = (date: string) =>
-  getRequest<ListResponseContentsDto>(`books?page=0&limit=10&publishedDate=${date}&orderBy=PublishedDate&direction=desc`);
+  getRequest<PageResponseBookDto>(
+    `/books?page=0&limit=10&publishedDate=2025-06-20&orderBy=PublishedDate&direction=desc`
+  );

--- a/function/get/commonGet.ts
+++ b/function/get/commonGet.ts
@@ -1,6 +1,19 @@
 export const getRequest = async <T>(endpoint: string): Promise<T> => {
   try {
     const response = await fetch(
+      `${process.env.NEXT_PUBLIC_BACKEND_URL}${endpoint}`
+    );
+    if (!response.ok) throw new Error(`Failed to GET from ${endpoint}`);
+    return (await response.json()) as T;
+  } catch (error) {
+    console.error(`Error GET ${endpoint}:`, error);
+    throw error;
+  }
+};
+
+export const getRequestForAdmin = async <T>(endpoint: string): Promise<T> => {
+  try {
+    const response = await fetch(
       `${process.env.NEXT_PUBLIC_BACKEND_ADMIN_URL}${endpoint}`
     );
     if (!response.ok) throw new Error(`Failed to GET from ${endpoint}`);

--- a/function/post/commonPost.ts
+++ b/function/post/commonPost.ts
@@ -24,3 +24,30 @@ export const postRequest = async <T>(
     throw error;
   }
 };
+
+export const adminPostRequest = async <T>(
+  endpoint: string,
+  bodyData: T
+): Promise<unknown> => {
+  try {
+    const response = await fetch(
+      `${process.env.NEXT_PUBLIC_BACKEND_ADMIN_URL}${endpoint}`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(bodyData),
+      }
+    );
+
+    if (!response.ok) {
+      throw new Error(`Failed to POST to ${endpoint}`);
+    }
+
+    return await response.json();
+  } catch (error) {
+    console.error(`Error POST ${endpoint}:`, error);
+    throw error;
+  }
+};

--- a/next.config.ts
+++ b/next.config.ts
@@ -14,7 +14,6 @@ const nextConfig: NextConfig = {
       : "http://localhost:3000",
   },
   images: {
-    
     remotePatterns: [
       {
         protocol: "https",
@@ -35,12 +34,16 @@ const nextConfig: NextConfig = {
         hostname: "search1.kakaocdn.net",
         pathname: "/thumb/**",
       },
+      {
+        protocol: "https",
+        hostname: "avatars.githubusercontent.com",
+      },
     ], // 책사진 도메인 허용
     domains: [
       "i.ytimg.com",
       "i0.wp.com",
       "image.yes24.com",
-      "minumsa.minumsa.com"
+      "minumsa.minumsa.com",
     ],
   },
   webpack: (config) => {

--- a/types/dto.ts
+++ b/types/dto.ts
@@ -58,15 +58,22 @@ export interface BookDto {
 
 export interface Detail {
   /** @format int64 */
-  id: number;
-  name: string;
-  engName?: string;
-  logo?: string;
-  isOfficial: boolean;
-  description?: string;
-  urls: UrlInfo[];
-  books: BookDto[];
-  tags: TagDto[];
+  isbn: string;
+  title: string;
+  detailUrl: string;
+  summary: string;
+  publishedDate: Date;
+  titleImage: string;
+  authorList: [];
+  translator: [];
+  price: number;
+  status: string;
+  publisher: {
+    id: number;
+    name: string;
+  };
+  contentsDtoList: [];
+  eventDtoList: [];
 }
 
 export interface Simple {

--- a/types/dto.ts
+++ b/types/dto.ts
@@ -262,7 +262,7 @@ export interface PageResponseContentsDto {
 }
 
 export interface ListResponseContentsDto {
-  items: ContentsDto[];
+  items: DisoveryContentsDto[];
   /** @format int32 */
   length: number;
 }
@@ -337,4 +337,21 @@ export interface EventRequestDto {
   location?: "ONLINE" | "OFFLINE";
   startDate?: string;
   endDate?: string;
+}
+
+export interface DisoveryContentsDto {
+  /** @format int64 */
+  id: number;
+  urls: UrlInfoTypeString[];
+  image?: string;
+  creator: UserDto;
+  createdAt: string;
+}
+
+enum ContentsType {
+  "Youtube" = "유튜브",
+  "Homepage" = "홈페이지",
+  "Blog" = "블로그",
+  "Link" = "링크",
+  "Profile" = "프로필",
 }

--- a/types/dto.ts
+++ b/types/dto.ts
@@ -355,7 +355,7 @@ export interface DisoveryContentsDto {
   createdAt: string;
 }
 
-enum ContentsType {
+export enum ContentsType {
   "Youtube" = "유튜브",
   "Homepage" = "홈페이지",
   "Blog" = "블로그",

--- a/types/dto.ts
+++ b/types/dto.ts
@@ -262,7 +262,7 @@ export interface PageResponseContentsDto {
 }
 
 export interface ListResponseContentsDto {
-  items: DisoveryContentsDto[];
+  items: ContentsDto[];
   /** @format int32 */
   length: number;
 }


### PR DESCRIPTION
## 📝작업 내용

### 메인화면 생일도서 api 응답 확인
> 메인 생일인 도서 연결(현재는 YYYY-MM-DD를 모두 입력해야됨) 
따라서 2025-06-22와 같이 입력시 [] 빈배열이 반환됨
현재는 책이 많이 존재하는 2025-06-20으로 날짜를 고정값으로 설정해서 받아오는 중


###  메인화면 오늘의 서재, 다가오는 일정, 디스커버리  api 응답 확인
> 오늘의 서재의 경우 현재는 빈배열이 오고 있어서 데모 컴포넌트 대체
디스커버리, 다가오는 일정의 경우 QA를 대비해 실제 컴포넌트로 연결햇으나 현재 빈배열로 아무것도 안보이는 상태


## 🏞️스크린샷 (선택)

x

## 💬리뷰 요구사항(선택)
close #11 
x